### PR TITLE
Fix login bug

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -54,6 +54,7 @@ export default function SettingsScreen() {
 
               if (!authRes.ok) {
                 const error = await authRes.json();
+                console.error("Firebase delete error:", error);
                 throw new Error(
                   error.error.message || "Failed to delete Auth account"
                 );
@@ -62,8 +63,8 @@ export default function SettingsScreen() {
               // Delete Firestore user document
               await deleteDoc(doc(db, "users", userId));
 
-              // Clear local storage & redirect
-              await AsyncStorage.clear();
+              await AsyncStorage.multiRemove(["userId", "userToken"]);
+
               router.replace("/login");
             } catch (err: any) {
               Alert.alert(

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,56 +1,119 @@
-import FontAwesome from '@expo/vector-icons/FontAwesome';
-import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
-import { useFonts } from 'expo-font';
-import { Stack } from 'expo-router';
-import * as SplashScreen from 'expo-splash-screen';
-import { useEffect } from 'react';
-import 'react-native-reanimated';
-import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import FontAwesome from "@expo/vector-icons/FontAwesome";
+import {
+  DarkTheme,
+  DefaultTheme,
+  ThemeProvider,
+} from "@react-navigation/native";
+import { useFonts } from "expo-font";
+import { Stack, useRouter } from "expo-router";
+import * as SplashScreen from "expo-splash-screen";
+import { useEffect, useState } from "react";
+import "react-native-reanimated";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 
-import { useColorScheme } from '@/components/useColorScheme';
-import { preloadAssets } from '@/utils/preloadAssets';
+import { useColorScheme } from "@/components/useColorScheme";
+import { preloadAssets } from "@/utils/preloadAssets";
 
-export {
-  // Catch any errors thrown by the Layout component.
-  ErrorBoundary,
-} from 'expo-router';
+export { ErrorBoundary } from "expo-router";
 
 export const unstable_settings = {
-  // Ensure that reloading on `/modal` keeps a back button present.
-  initialRouteName: '(tabs)',
+  initialRouteName: "(tabs)",
 };
 
-// Prevent the splash screen from auto-hiding before asset loading is complete.
+const FIREBASE_API_KEY = "AIzaSyC6kcCBZoQGxuFAv7VVlY674Ul7C9dyNwU";
+
 SplashScreen.preventAutoHideAsync();
 
 export default function RootLayout() {
   const [loaded, error] = useFonts({
-    SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
+    SpaceMono: require("../assets/fonts/SpaceMono-Regular.ttf"),
     ...FontAwesome.font,
   });
 
+  const [checkingAuth, setCheckingAuth] = useState(true);
+  const router = useRouter();
+
   useEffect(() => {
-    if (error) throw error;
+    if (error) {
+      console.error("Font load error:", error);
+      throw error;
+    }
   }, [error]);
 
   useEffect(() => {
-    const loadResources = async () => {
+    const loadResourcesAndCheckAuth = async () => {
       try {
-        await preloadAssets(); // preload all images
+        console.log("🔄 Preloading assets...");
+        await preloadAssets();
+        console.log("✅ Assets preloaded");
+
+        const idToken = await AsyncStorage.getItem("userToken");
+        const userId = await AsyncStorage.getItem("userId");
+        console.log("📦 Retrieved from storage:", { idToken, userId });
+
+        if (!idToken || !userId) {
+          console.log("🚫 Missing token or userId. Redirecting to login...");
+          await AsyncStorage.multiRemove(["userId", "userToken"]);
+          setTimeout(() => {
+            router.replace("/(auth)/login");
+          }, 0);
+
+          return;
+        }
+
+        console.log("🔐 Verifying token with Firebase...");
+        const res = await fetch(
+          `https://identitytoolkit.googleapis.com/v1/accounts:lookup?key=${FIREBASE_API_KEY}`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ idToken }),
+          }
+        );
+
+        const data = await res.json();
+
+        if (!res.ok) {
+          console.error(
+            "❌ Invalid token. Firebase says:",
+            data.error?.message
+          );
+          await AsyncStorage.multiRemove(["userId", "userToken"]);
+          console.log("🔁 Redirecting to login...");
+          setTimeout(() => {
+            router.replace("/(auth)/login");
+          }, 0);
+
+          return;
+        }
+
+        console.log("✅ Token is valid. Continuing to tabs.");
       } catch (e) {
-        console.error('Error preloading assets', e);
+        console.error("🔥 Auth check failed:", e);
+        await AsyncStorage.multiRemove(["userId", "userToken"]);
+        console.log("🔁 Redirecting to login (from catch block)...");
+        setTimeout(() => {
+          router.replace("/(auth)/login");
+        }, 0);
       } finally {
-        SplashScreen.hideAsync(); // only hide splash after preloading is done
+        setCheckingAuth(false);
+        console.log("🟢 Finished auth check. Hiding splash.");
+        SplashScreen.hideAsync();
       }
     };
 
     if (loaded) {
-      loadResources();
+      console.log("🎉 Fonts loaded. Starting init.");
+      loadResourcesAndCheckAuth();
+    } else {
+      console.log("⏳ Waiting for fonts...");
     }
   }, [loaded]);
 
-  if (!loaded) {
-    return null;
+  if (!loaded || checkingAuth) {
+    console.log("⏳ App is still initializing...");
+    return null; // or return <Text>Loading...</Text>
   }
 
   return (
@@ -64,10 +127,10 @@ function RootLayoutNav() {
   const colorScheme = useColorScheme();
 
   return (
-    <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+    <ThemeProvider value={colorScheme === "dark" ? DarkTheme : DefaultTheme}>
       <Stack>
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-        <Stack.Screen name="modal" options={{ presentation: 'modal' }} />
+        <Stack.Screen name="modal" options={{ presentation: "modal" }} />
       </Stack>
     </ThemeProvider>
   );

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -44,16 +44,12 @@ export default function RootLayout() {
   useEffect(() => {
     const loadResourcesAndCheckAuth = async () => {
       try {
-        console.log("🔄 Preloading assets...");
         await preloadAssets();
-        console.log("✅ Assets preloaded");
 
         const idToken = await AsyncStorage.getItem("userToken");
         const userId = await AsyncStorage.getItem("userId");
-        console.log("📦 Retrieved from storage:", { idToken, userId });
 
         if (!idToken || !userId) {
-          console.log("🚫 Missing token or userId. Redirecting to login...");
           await AsyncStorage.multiRemove(["userId", "userToken"]);
           setTimeout(() => {
             router.replace("/(auth)/login");
@@ -62,7 +58,6 @@ export default function RootLayout() {
           return;
         }
 
-        console.log("🔐 Verifying token with Firebase...");
         const res = await fetch(
           `https://identitytoolkit.googleapis.com/v1/accounts:lookup?key=${FIREBASE_API_KEY}`,
           {
@@ -80,39 +75,34 @@ export default function RootLayout() {
             data.error?.message
           );
           await AsyncStorage.multiRemove(["userId", "userToken"]);
-          console.log("🔁 Redirecting to login...");
+
           setTimeout(() => {
             router.replace("/(auth)/login");
           }, 0);
 
           return;
         }
-
-        console.log("✅ Token is valid. Continuing to tabs.");
       } catch (e) {
         console.error("🔥 Auth check failed:", e);
         await AsyncStorage.multiRemove(["userId", "userToken"]);
-        console.log("🔁 Redirecting to login (from catch block)...");
+
         setTimeout(() => {
           router.replace("/(auth)/login");
         }, 0);
       } finally {
         setCheckingAuth(false);
-        console.log("🟢 Finished auth check. Hiding splash.");
+
         SplashScreen.hideAsync();
       }
     };
 
     if (loaded) {
-      console.log("🎉 Fonts loaded. Starting init.");
       loadResourcesAndCheckAuth();
     } else {
-      console.log("⏳ Waiting for fonts...");
     }
   }, [loaded]);
 
   if (!loaded || checkingAuth) {
-    console.log("⏳ App is still initializing...");
     return null; // or return <Text>Loading...</Text>
   }
 


### PR DESCRIPTION
#### Summary
This PR resolves a bug where users could still access the app even after their Firebase Auth account was deleted. The root cause was stale tokens stored in AsyncStorage.

#### What's Changed
- Added Firebase Auth token validation in `app/_layout.tsx` using the `/accounts:lookup` endpoint.
- Replaced all `AsyncStorage.clear()` calls with `multiRemove()` to avoid iOS crash from non-existent storage directories.
- Used `setTimeout(..., 0)` to defer `router.replace()` calls, fixing the "navigate before mounting" error from `expo-router`.
